### PR TITLE
add a central interface to run model in start.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ test.ipynb
 secrets.txt
 jc_local_work/
 jc_own_test/
+Close/run/run_p_GDP_D.py
+Close/run/test_util.py

--- a/Close/models.py
+++ b/Close/models.py
@@ -24,8 +24,16 @@ TODO:
 - Gemini
 '''
 
-### Load secrets
+## Load secrets
+## search the file in different levels
 SECRET_FILE = '../secrets.txt'
+
+if not os.path.exists(SECRET_FILE):
+    SECRET_FILE = 'secrets.txt'
+    if not os.path.exists(SECRET_FILE):
+        SECRET_FILE = '../../secrets.txt'
+
+
 with open(SECRET_FILE) as f:
     lines = f.readlines()
     for line in lines:

--- a/Close/run/path.py
+++ b/Close/run/path.py
@@ -1,0 +1,14 @@
+import os
+# path to the model type dir
+# assume this file is placed in run folder of the closed and open
+
+
+# Determine the directory of the current file
+current_file_directory = os.path.dirname(os.path.abspath(__file__))
+
+# Set the path to the model type directory
+MODEL_TYPE_PATH = os.path.dirname(current_file_directory)
+HP_HARD_PATH = os.path.dirname(os.path.dirname(current_file_directory))
+
+
+

--- a/Close/run/run_cmp_GCP_D.py
+++ b/Close/run/run_cmp_GCP_D.py
@@ -6,6 +6,7 @@ from models import *
 from prompts import gcp_dPrompts
 from check.check_cmp_GCP_D import *
 from utils import parse_xml_to_dict
+from utils import find_data_path
 
 import pandas as pd
 import numpy as np
@@ -24,12 +25,18 @@ args = parser.parse_args()
 # Script logic using args.model as the model name
 MODEL = str(args.model)
 
+
 DATA_PATH = '../Data/GCP_Decision/'
 RESULT_PATH = '../Results/'
+
+if not os.path.exists(DATA_PATH) or not os.path.exists(RESULT_PATH):
+    DATA_PATH,RESULT_PATH = find_data_path(os.path.abspath(__file__))
+    
 
 def load_data():
     data_path = DATA_PATH
     all_data = []
+    # change to 1 for test result gene reason
     for file_num in range(10):
         with open(data_path + "decision_data_GCP_{}.txt".format(file_num)) as f:
             data = f.read()

--- a/Close/run/run_cmp_KSP.py
+++ b/Close/run/run_cmp_KSP.py
@@ -6,6 +6,7 @@ from models import *
 from prompts import kspPrompts
 from check.check_cmp_KSP import *
 from utils import parse_xml_to_dict
+from utils import find_data_path
 
 import pandas as pd
 import numpy as np
@@ -26,6 +27,9 @@ MODEL = str(args.model)
 
 DATA_PATH = '../Data/KSP/'
 RESULT_PATH = '../Results/'
+
+if not os.path.exists(DATA_PATH) or not os.path.exists(RESULT_PATH):
+    DATA_PATH,RESULT_PATH = find_data_path(os.path.abspath(__file__))
 
 def load_data():
     data_path = DATA_PATH

--- a/Close/run/run_cmp_TSP_D.py
+++ b/Close/run/run_cmp_TSP_D.py
@@ -6,6 +6,7 @@ from models import *
 from prompts import tsp_dPrompts
 from check.check_cmp_TSP_D import *
 from utils import parse_xml_to_dict
+from utils import find_data_path
 
 import pandas as pd
 import numpy as np
@@ -26,6 +27,9 @@ MODEL = str(args.model)
 
 DATA_PATH = '../Data/TSP_Decision/'
 RESULT_PATH = '../Results/'
+
+if not os.path.exists(DATA_PATH) or not os.path.exists(RESULT_PATH):
+    DATA_PATH,RESULT_PATH = find_data_path(os.path.abspath(__file__))
 
 def load_data():
     data_path = DATA_PATH

--- a/Close/run/run_hard_GCP.py
+++ b/Close/run/run_hard_GCP.py
@@ -5,6 +5,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from models import *
 from prompts import gcpPrompts
 from check.check_hard_GCP import *
+from utils import find_data_path
 
 import pandas as pd
 import numpy as np
@@ -31,6 +32,9 @@ DATA_PATH = '../Data/GCP/'
 RESULT_PATH = '../Results/'
 
 
+if not os.path.exists(DATA_PATH) or not os.path.exists(RESULT_PATH):
+    DATA_PATH,RESULT_PATH = find_data_path(os.path.abspath(__file__))
+    
 def load_data():
     data_path = DATA_PATH
     all_data = []

--- a/Close/run/run_hard_MSP.py
+++ b/Close/run/run_hard_MSP.py
@@ -5,6 +5,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from models import *
 from prompts import mspPrompts
 from check.check_hard_MSP import *
+from utils import find_data_path
 
 import pandas as pd
 import numpy as np
@@ -29,6 +30,9 @@ MODEL = str(args.model)
 
 DATA_PATH = '../Data/MSP/'
 RESULT_PATH = '../Results/'
+
+if not os.path.exists(DATA_PATH) or not os.path.exists(RESULT_PATH):
+    DATA_PATH,RESULT_PATH = find_data_path(os.path.abspath(__file__))
 
 def load_data():
     data_path = DATA_PATH

--- a/Close/run/run_hard_TSP.py
+++ b/Close/run/run_hard_TSP.py
@@ -5,6 +5,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from models import *
 from prompts import tspPrompts
 from check.check_hard_TSP import *
+from utils import find_data_path
 
 import pandas as pd
 import numpy as np
@@ -29,6 +30,10 @@ MODEL = str(args.model)
 
 DATA_PATH = '../Data/TSP/'
 RESULT_PATH = '../Results/'
+
+if not os.path.exists(DATA_PATH) or not os.path.exists(RESULT_PATH):
+    DATA_PATH,RESULT_PATH = find_data_path(os.path.abspath(__file__))
+
 
 def load_data():
     data_path = DATA_PATH

--- a/Close/run/run_p_BSP.py
+++ b/Close/run/run_p_BSP.py
@@ -6,6 +6,7 @@ from models import *
 from prompts import bspPrompts
 from check.check_p_BSP import *
 from utils import parse_xml_to_dict
+from utils import find_data_path
 
 import pandas as pd
 import numpy as np
@@ -26,6 +27,9 @@ MODEL = str(args.model)
 
 DATA_PATH = '../Data/BSP/'
 RESULT_PATH = '../Results/'
+
+if not os.path.exists(DATA_PATH) or not os.path.exists(RESULT_PATH):
+    DATA_PATH,RESULT_PATH = find_data_path(os.path.abspath(__file__))
 
 def load_data():
     data_path = DATA_PATH

--- a/Close/run/run_p_BSP_few.py
+++ b/Close/run/run_p_BSP_few.py
@@ -6,6 +6,7 @@ from models import *
 from prompts import bspPrompts, mfpPrompts
 from check.check_p_BSP import *
 from utils import parse_xml_to_dict
+from utils import find_data_path
 
 import pandas as pd
 import numpy as np
@@ -33,6 +34,10 @@ PROMPT_STYLE = str(args.prompt_style)
 DATA_PATH = '../Data/BSP/'
 RESULT_PATH = '../Results_fewshot/'
 EXAMPLE_PATH = DATA_PATH
+
+if not os.path.exists(DATA_PATH) or not os.path.exists(RESULT_PATH):
+    DATA_PATH,RESULT_PATH = find_data_path(os.path.abspath(__file__))
+    EXAMPLE_PATH = DATA_PATH
 
 def load_data():
     data_path = DATA_PATH

--- a/Close/run/run_p_EDP.py
+++ b/Close/run/run_p_EDP.py
@@ -6,6 +6,7 @@ from models import *
 from prompts import edpPrompts
 from check.check_p_EDP import *
 from utils import parse_xml_to_dict
+from utils import find_data_path
 
 import json
 import argparse
@@ -24,6 +25,9 @@ MODEL = str(args.model)
 
 DATA_PATH = '../Data/EDP/'
 RESULT_PATH = '../Results/'
+
+if not os.path.exists(DATA_PATH) or not os.path.exists(RESULT_PATH):
+    DATA_PATH,RESULT_PATH = find_data_path(os.path.abspath(__file__))
 
 def load_data():
     data_path = DATA_PATH

--- a/Close/run/run_p_EDP_few.py
+++ b/Close/run/run_p_EDP_few.py
@@ -6,6 +6,7 @@ from models import *
 from prompts import edpPrompts, bspPrompts
 from check.check_p_EDP import *
 from utils import parse_xml_to_dict
+from utils import find_data_path
 
 import pandas as pd
 import numpy as np
@@ -33,6 +34,10 @@ PROMPT_STYLE = str(args.prompt_style)
 DATA_PATH = '../Data/EDP/'
 RESULT_PATH = '../Results_fewshot/'
 EXAMPLE_PATH = DATA_PATH
+
+if not os.path.exists(DATA_PATH) or not os.path.exists(RESULT_PATH):
+    DATA_PATH,RESULT_PATH = find_data_path(os.path.abspath(__file__))
+    EXAMPLE_PATH = DATA_PATH
 
 def load_data():
     data_path = DATA_PATH

--- a/Close/run/run_p_MFP.py
+++ b/Close/run/run_p_MFP.py
@@ -6,6 +6,7 @@ from models import *
 from prompts import mfpPrompts
 from check.check_p_MFP import *
 from utils import parse_xml_to_dict
+from utils import find_data_path
 
 import pandas as pd
 import numpy as np
@@ -26,6 +27,10 @@ MODEL = str(args.model)
 
 DATA_PATH = '../Data/MFP/'
 RESULT_PATH = '../Results/'
+
+if not os.path.exists(DATA_PATH) or not os.path.exists(RESULT_PATH):
+    DATA_PATH,RESULT_PATH = find_data_path(os.path.abspath(__file__))
+    EXAMPLE_PATH = DATA_PATH
 
 def load_data():
     data_path = DATA_PATH

--- a/Close/run/run_p_MFP_few.py
+++ b/Close/run/run_p_MFP_few.py
@@ -6,6 +6,8 @@ from models import *
 from prompts import mfpPrompts, bspPrompts
 from check.check_p_MFP import *
 from utils import parse_xml_to_dict
+from utils import find_data_path
+
 
 import pandas as pd
 import numpy as np
@@ -32,6 +34,10 @@ PROMPT_STYLE = str(args.prompt_style)
 DATA_PATH = '../Data/MFP/'
 RESULT_PATH = '../Results_fewshot/'
 EXAMPLE_PATH = DATA_PATH
+
+if not os.path.exists(DATA_PATH) or not os.path.exists(RESULT_PATH):
+    DATA_PATH,RESULT_PATH = find_data_path(os.path.abspath(__file__))
+    EXAMPLE_PATH = DATA_PATH
 
 # DATA_PATH = '../Data/New_replace/'
 # RESULT_PATH = '../Results_fewshot/MFP_new/'

--- a/Close/run/run_p_SPP.py
+++ b/Close/run/run_p_SPP.py
@@ -6,6 +6,7 @@ from models import *
 from prompts import sppPrompts
 from check.check_p_SPP import *
 from utils import parse_xml_to_dict
+from utils import find_data_path
 
 import pandas as pd
 import numpy as np
@@ -26,6 +27,10 @@ MODEL = str(args.model)
 
 DATA_PATH = '../Data/SPP/'
 RESULT_PATH = '../Results/'
+
+if not os.path.exists(DATA_PATH) or not os.path.exists(RESULT_PATH):
+    DATA_PATH,RESULT_PATH = find_data_path(os.path.abspath(__file__))
+    EXAMPLE_PATH = DATA_PATH
 
 def load_data():
     data_path = DATA_PATH

--- a/Close/run/utils.py
+++ b/Close/run/utils.py
@@ -1,5 +1,7 @@
 import xml.etree.ElementTree as ET
 import ast
+import os
+from path import MODEL_TYPE_PATH, HP_HARD_PATH
 
 
 def append_root_tags(string):
@@ -36,3 +38,52 @@ def parse_xml_to_dict(xml_string: str):
     output = ast.literal_eval(final_answer_element.text.strip())
     # print(reasoning_element.text)
     return output, reasoning
+
+
+def find_data_path(file_path):
+    """
+    Determine the data file path and result file path based on a given file path.
+
+    This function parses the file name from the provided `file_path`, identifies specific components 
+    of the file name, and constructs paths for the data file and result file based on these components 
+    and predefined directory structures. It will also create the result folder, if not exist.
+
+    Parameters:
+    file_path (str): The file path of the file for which the data and result paths are to be determined.
+
+    Returns:
+    tuple: A tuple containing two strings. The first string is the path for the data file, and the second 
+    string is the path for the result file. 
+
+    The function assumes a specific naming convention for the files. The file name is expected to be in 
+    the format 'prefix_tasktype_taskname_suffix.ext', where 'tasktype' and 'taskname' are used to determine 
+    the paths. If the suffix is 'few', it indicates a few-shot scenario, and if it is 'D', it indicates a 
+    decision-related task. These suffixes modify the result file name accordingly. The paths are constructed 
+    using predefined base paths ('MODEL_TYPE_PATH' and 'NP_HARD_PATH').
+    """
+    
+    file_name = os.path.basename(file_path)
+    file_name, file_extension = os.path.splitext(file_name)
+    name_part = file_name.split('_')
+    
+    task_file_name = name_part[2]
+    res_file_name = 'Results'
+
+    if len(name_part) == 4:
+        if name_part[-1] == 'few':
+            res_file_name += '_fewshot'
+        elif name_part[-1] == 'D':
+            task_file_name += '_Decision'
+    
+    data_file_name = os.path.join(HP_HARD_PATH, 'Data' ,task_file_name) + os.sep
+    res_file_name = os.path.join(MODEL_TYPE_PATH, res_file_name) + os.sep
+
+    if not os.path.exists(res_file_name):
+        # Create the directory along with any necessary intermediate directories
+        os.makedirs(res_file_name)
+        print(f"Directory created at {res_file_name}")
+    else:
+        # If the directory already exists
+        print(f"Directory already exists at {res_file_name}")
+
+    return data_file_name, res_file_name

--- a/Open/run/path.py
+++ b/Open/run/path.py
@@ -1,0 +1,14 @@
+import os
+# path to the model type dir
+# assume this file is placed in run folder of the closed and open
+
+
+# Determine the directory of the current file
+current_file_directory = os.path.dirname(os.path.abspath(__file__))
+
+# Set the path to the model type directory
+MODEL_TYPE_PATH = os.path.dirname(current_file_directory)
+HP_HARD_PATH = os.path.dirname(os.path.dirname(current_file_directory))
+
+
+

--- a/Open/run/run_cmp_GCP_D.py
+++ b/Open/run/run_cmp_GCP_D.py
@@ -12,6 +12,7 @@ import json
 import argparse
 from tqdm import tqdm 
 from utils import run_opensource_models
+from utils import find_data_path
 
 def load_data():
     data_path = DATA_PATH
@@ -88,9 +89,39 @@ if __name__ == '__main__':
     # Script logic using args.model as the model name
     MODEL = str(args.model)
 
-    DATA_PATH = args.data_dir
+    # original path config
+    # DATA_PATH = args.data_dir
+    
+    # if args.tuned_model_dir:
+    #     RESULT_PATH = '../Results/finetuned/'
+    #     if 'test_1' in args.data_dir:
+    #         RESULT_PATH += 'test_1/'
+    #     elif 'test_2' in args.data_dir:
+    #         RESULT_PATH += 'test_2/'
+    #     else:
+    #         RESULT_PATH += 'original/'
+    # else:
+    #     RESULT_PATH = '../Results/'
+    #     if 'test_1' in args.data_dir:
+    #         RESULT_PATH += 'test_1/'
+    #     elif 'test_2' in args.data_dir:
+    #         RESULT_PATH += 'test_2/'
+
+
+    ## new interface code please test and check 
+
+
+    DEFAULT_DATA_PATH,DEFAULT_RESULT_PATH = find_data_path(os.path.abspath(__file__))
+
+    if args.data_dir != '../Data/GCP_Decision/':
+        DATA_PATH = args.data_dir
+    else:
+        DATA_PATH = DEFAULT_DATA_PATH
+    
+    RESULT_PATH = DEFAULT_RESULT_PATH
+
     if args.tuned_model_dir:
-        RESULT_PATH = '../Results/finetuned/'
+        RESULT_PATH += 'finetuned/'
         if 'test_1' in args.data_dir:
             RESULT_PATH += 'test_1/'
         elif 'test_2' in args.data_dir:
@@ -98,11 +129,13 @@ if __name__ == '__main__':
         else:
             RESULT_PATH += 'original/'
     else:
-        RESULT_PATH = '../Results/'
         if 'test_1' in args.data_dir:
             RESULT_PATH += 'test_1/'
         elif 'test_2' in args.data_dir:
             RESULT_PATH += 'test_2/'
+
+
+    
 
     # load data
     gcp_d_Data = load_data()

--- a/Open/run/utils.py
+++ b/Open/run/utils.py
@@ -3,6 +3,7 @@ import ast
 import sys
 import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from path import MODEL_TYPE_PATH, HP_HARD_PATH
 
 from models import *
 
@@ -61,3 +62,52 @@ def run_opensource_models(args, MODEL, all_prompts):
     else:
         raise NotImplementedError
     return output
+
+
+def find_data_path(file_path):
+    """
+    Determine the data file path and result file path based on a given file path.
+
+    This function parses the file name from the provided `file_path`, identifies specific components 
+    of the file name, and constructs paths for the data file and result file based on these components 
+    and predefined directory structures. It will also create the result folder, if not exist.
+
+    Parameters:
+    file_path (str): The file path of the file for which the data and result paths are to be determined.
+
+    Returns:
+    tuple: A tuple containing two strings. The first string is the path for the data file, and the second 
+    string is the path for the result file. 
+
+    The function assumes a specific naming convention for the files. The file name is expected to be in 
+    the format 'prefix_tasktype_taskname_suffix.ext', where 'tasktype' and 'taskname' are used to determine 
+    the paths. If the suffix is 'few', it indicates a few-shot scenario, and if it is 'D', it indicates a 
+    decision-related task. These suffixes modify the result file name accordingly. The paths are constructed 
+    using predefined base paths ('MODEL_TYPE_PATH' and 'NP_HARD_PATH').
+    """
+    
+    file_name = os.path.basename(file_path)
+    file_name, file_extension = os.path.splitext(file_name)
+    name_part = file_name.split('_')
+    
+    task_file_name = name_part[2]
+    res_file_name = 'Results'
+
+    if len(name_part) == 4:
+        if name_part[-1] == 'few':
+            res_file_name += '_fewshot'
+        elif name_part[-1] == 'D':
+            task_file_name += '_Decision'
+    
+    data_file_name = os.path.join(HP_HARD_PATH, 'Data' ,task_file_name) + os.sep
+    res_file_name = os.path.join(MODEL_TYPE_PATH, res_file_name) + os.sep
+
+    if not os.path.exists(res_file_name):
+        # Create the directory along with any necessary intermediate directories
+        os.makedirs(res_file_name)
+        print(f"Directory created at {res_file_name}")
+    else:
+        # If the directory already exists
+        print(f"Directory already exists at {res_file_name}")
+
+    return data_file_name, res_file_name

--- a/start.py
+++ b/start.py
@@ -1,0 +1,107 @@
+import sys
+import os
+import argparse
+import subprocess
+
+def main():
+    """
+    Main function to execute a specific test script based on the arguments provided.
+
+    This script sets up an argument parser to process command line arguments for running different tests on a learning model system (LLMS). 
+    The script allows users to specify the type of model (open or close), the test to run, the model name, and additional options for few-shot learning and prompt styles.
+
+    The script dynamically constructs the command to run the appropriate test script based on the provided arguments. 
+    It handles different cases for open and close model types, including adjustments for few-shot learning and prompt styles.
+    IMPORTANT: please assume the current working directory is NPHARDEVAL
+
+    Raises:
+        NameError: If 'prompt_style' is not specified when required.
+
+    Note:
+        This script must be run with the necessary command line arguments. 
+        It does not execute any functionality if the arguments are not provided or are incorrect.
+
+    example:
+        cd NPHARDEVAL 
+        python start.py Close p_BSP gpt-4-1106-preview --fewshot True --prompt_style self
+        python start.py Close hard_TSP gpt-4-1106-preview
+        python start.py Close cmp_KSP gpt-4-1106-preview  
+
+    """
+    # This is the outer arg parser.
+    parser = argparse.ArgumentParser(description='parse user to run different test on llms')
+
+    parser.add_argument('model_type', 
+                        metavar='model type', type=str, nargs=1,
+                        choices=['Open','Close'],
+                        help='''argument to choose open model or close model,
+                                open for open model,
+                                close for closed model''')
+
+    parser.add_argument('test', 
+                        metavar='test name', type=str, nargs=1,
+                        choices=['cmp_GCP_D','cmp_KSP','cmp_TSP_D','hard_GCP',
+                                'hard_MSP','hard_TSP','p_BSP','p_EDP','p_MFP','p_SPP'],
+                        help='''argument to choose actual test''')
+
+    parser.add_argument('--fewshot', 
+                        metavar='few shot input', type=bool, nargs=1,
+                        choices=[True,False],
+                        help='''argument to choose if fewshot''')
+
+    parser.add_argument('model', 
+                        metavar='model name', type=str, nargs=1,
+                        help='''argument to choose llm model''')
+
+    parser.add_argument('--prompt_style', 
+                        metavar='few shot input', type=str, nargs=1,
+                        choices=['self','other'],
+                        help='''argument to prompt style''')
+
+    # args for open model
+    # important please assume the current working directory is NPHARDEVAL
+    parser.add_argument('--data_dir', type=str, default='Data/BSP/', help='Data/finetune_data/test_1/BSP/')
+    parser.add_argument('--tuned_model_dir', type=str, default='')
+    parser.add_argument('--difficulty_level', type=int, default=0, help="-5, -4, -3, ...")
+    parser.add_argument('--example_number', type=int, default=5, help="2,3,4,5")
+
+    arg = parser.parse_args()
+    model_type = arg.model_type[0] 
+    test_name = f'run_{arg.test[0]}'
+    prompt_style = ''
+
+    # edit _few to run file name
+    if arg.fewshot and arg.fewshot[0] == True and model_type == 'Close':
+        test_name +='_few'
+    if arg.prompt_style:
+        # the space is left to sep model name and prompt style
+        prompt_style = f'{arg.prompt_style[0]}'
+    test_name += '.py'
+
+    model_name = arg.model[0]
+
+    inner_parser_script = os.path.join(os.getcwd(), model_type,'run',test_name)
+
+    # handle close case
+    if model_type == 'Close':
+        # pass in different param based on if fewshot 
+        if arg.fewshot and arg.fewshot[0] == True:
+            if not prompt_style or prompt_style == '':
+                raise NameError('Please choose prompt_style from self and other')
+            command = [sys.executable, inner_parser_script, model_name, prompt_style]
+        else:
+            command = [sys.executable, inner_parser_script, model_name]
+    # handle open case
+    else:
+        command = [
+        sys.executable, inner_parser_script, 
+        '--data_dir', arg.data_dir,
+        '--tuned_model_dir', arg.tuned_model_dir,
+        '--difficulty_level', str(arg.difficulty_level),
+        '--example_number', str(arg.example_number)
+    ]
+
+    subprocess.run(command)               
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adding an interface in start.py under root folder, which allows to run different tests at a single place(example is in docstring). Adding path file under run folder in both open and closed model. Adding a path calculator func in util.py in open and closed folder using the path file. This calculator will calculate the data path for the run_<model_name>.py files. 

The interface for open model is only added in [run_cmp_GCP_D.py] and requires testing.

Future work could be done by moving the calculator out to aviod duplicated code and move the path.py to the root folder.  

